### PR TITLE
Add Admin Mode: restrict register/unregister to teachers only

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -89,8 +89,10 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str, admin: bool = False):
+    """Sign up a student for an activity (admin only)"""
+    if not admin:
+        raise HTTPException(status_code=403, detail="Admin login required to sign up participants.")
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +113,10 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
+def unregister_from_activity(activity_name: str, email: str, admin: bool = False):
+    """Unregister a student from an activity (admin only)"""
+    if not admin:
+        raise HTTPException(status_code=403, detail="Admin login required to unregister participants.")
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,36 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const adminLoginForm = document.getElementById("admin-login-form");
+  const adminPasswordInput = document.getElementById("admin-password");
+  const adminStatusDiv = document.getElementById("admin-status");
+
+  // Simple admin password (for demo only)
+  const ADMIN_PASSWORD = "teach2026";
+
+  function isAdmin() {
+    return localStorage.getItem("isAdmin") === "true";
+  }
+
+  function setAdmin(status) {
+    localStorage.setItem("isAdmin", status ? "true" : "false");
+    adminStatusDiv.textContent = status ? "Admin mode enabled." : "Not logged in as admin.";
+    adminStatusDiv.classList.remove("hidden");
+    // Refresh UI to show/hide admin features
+    fetchActivities();
+  }
+
+  adminLoginForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (adminPasswordInput.value === ADMIN_PASSWORD) {
+      setAdmin(true);
+      adminLoginForm.reset();
+    } else {
+      setAdmin(false);
+      adminStatusDiv.textContent = "Incorrect password.";
+      adminStatusDiv.classList.remove("hidden");
+    }
+  });
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,29 +42,29 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
         const activityCard = document.createElement("div");
         activityCard.className = "activity-card";
 
-        const spotsLeft =
-          details.max_participants - details.participants.length;
+        const spotsLeft = details.max_participants - details.participants.length;
 
-        // Create participants HTML with delete icons instead of bullet points
+        // Only show delete buttons if admin
         const participantsHTML =
           details.participants.length > 0
             ? `<div class="participants-section">
-              <h5>Participants:</h5>
-              <ul class="participants-list">
-                ${details.participants
-                  .map(
-                    (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
-                  )
-                  .join("")}
-              </ul>
-            </div>`
+                <h5>Participants:</h5>
+                <ul class="participants-list">
+                  ${details.participants
+                    .map(
+                      (email) =>
+                        `<li><span class="participant-email">${email}</span>${isAdmin() ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>` : ""}</li>`
+                    )
+                    .join("")}
+                </ul>
+              </div>`
             : `<p><em>No participants yet</em></p>`;
 
         activityCard.innerHTML = `
@@ -56,10 +86,12 @@ document.addEventListener("DOMContentLoaded", () => {
         activitySelect.appendChild(option);
       });
 
-      // Add event listeners to delete buttons
-      document.querySelectorAll(".delete-btn").forEach((button) => {
-        button.addEventListener("click", handleUnregister);
-      });
+      // Add event listeners to delete buttons (only if admin)
+      if (isAdmin()) {
+        document.querySelectorAll(".delete-btn").forEach((button) => {
+          button.addEventListener("click", handleUnregister);
+        });
+      }
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -69,15 +101,19 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!isAdmin()) {
+      messageDiv.textContent = "Admin login required to unregister participants.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      return;
+    }
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
 
     try {
       const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/unregister?email=${encodeURIComponent(email)}`,
+        `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}&admin=true`,
         {
           method: "DELETE",
         }
@@ -88,8 +124,6 @@ document.addEventListener("DOMContentLoaded", () => {
       if (response.ok) {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
-
-        // Refresh activities list to show updated participants
         fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
@@ -97,8 +131,6 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
       setTimeout(() => {
         messageDiv.classList.add("hidden");
       }, 5000);
@@ -114,14 +146,19 @@ document.addEventListener("DOMContentLoaded", () => {
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
+    if (!isAdmin()) {
+      messageDiv.textContent = "Admin login required to sign up participants.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      return;
+    }
+
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
     try {
       const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/signup?email=${encodeURIComponent(email)}`,
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}&admin=true`,
         {
           method: "POST",
         }
@@ -133,8 +170,6 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
-
-        // Refresh activities list to show updated participants
         fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
@@ -142,8 +177,6 @@ document.addEventListener("DOMContentLoaded", () => {
       }
 
       messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
       setTimeout(() => {
         messageDiv.classList.add("hidden");
       }, 5000);

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -21,6 +21,18 @@
         </div>
       </section>
 
+      <section id="admin-login-container">
+        <h3>Admin Login</h3>
+        <form id="admin-login-form">
+          <div class="form-group">
+            <label for="admin-password">Teacher Password:</label>
+            <input type="password" id="admin-password" required placeholder="Enter admin password" />
+          </div>
+          <button type="submit">Login as Admin</button>
+        </form>
+        <div id="admin-status" class="hidden"></div>
+      </section>
+
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
         <form id="signup-form">


### PR DESCRIPTION
This pull request implements Admin Mode:
- Adds an admin login form (password: teach2026)
- Only admins can register or unregister students
- The ❌ button for removing participants is only visible to admins
- The backend enforces admin status for these actions

This addresses issue #5 (Admin Mode).